### PR TITLE
Catch and log exceptions thrown by yaup StringUtil.populatePattern()

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,26 @@
+# FAQ
+
+## No more authentication methods available?
+Q: What does the following error mean when i try running a script;
+
+```
+17:03:37.180 [command-1] ERROR io.hyperfoil.tools.qdup.SshSession - Exception while connecting to user@myserver.com
+No more authentication methods available
+org.apache.sshd.common.SshException: No more authentication methods available
+	at org.apache.sshd.client.session.ClientUserAuthService.tryNext(ClientUserAuthService.java:322)
+	at org.apache.sshd.client.session.ClientUserAuthService.processUserAuth(ClientUserAuthService.java:258)
+        ...
+```
+
+A: qDup  uses ssh terminal sessions so need to be able to connect to the target machine without providing a password via prompt. This error is caused by not having the correct ssh credentials configured for the client machine trying to connect to the server machine. Please ensure that you can open a ssh terminal to ``user@myserver.com`` from the client machine you are running the qDup script from without needing to enter a password prompt.
+
+## Failed to load qdup.yaml as yaml only
+
+Q: Why does the parser fail witl the following error message?
+```
+13:44:19.759 [main] ERROR i.h.tools.qdup.config.yaml.Parser - Failed to load qdup.yaml as yaml only
+mapping values are not allowed here
+ in 'string', line 6, column 14:
+            regex: "\\s*Active: (?<active>\\w+) \ ... 
+```
+A: 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>io.hyperfoil.tools</groupId>
             <artifactId>yaup</artifactId>
-            <version>0.4</version>
+            <version>0.5-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
@@ -29,6 +29,7 @@ import io.hyperfoil.tools.qdup.State;
 
 import io.hyperfoil.tools.yaup.AsciiArt;
 import io.hyperfoil.tools.yaup.HashedLists;
+import io.hyperfoil.tools.yaup.PopulatePatternException;
 import org.apache.commons.jexl3.JexlContext;
 
 import org.slf4j.ext.XLogger;
@@ -504,7 +505,13 @@ public abstract class Cmd {
 
    public static Object getStateValue(String name, Cmd cmd, State state, Ref ref, boolean replaceUndefined, String separator) {
       CmdStateRefMap map = new CmdStateRefMap(cmd,state,ref);
-      return StringUtil.populatePattern(name,map,replaceUndefined,StringUtil.PATTERN_PREFIX,separator,StringUtil.PATTERN_SUFFIX);
+      try {
+          return StringUtil.populatePattern(name, map, replaceUndefined, StringUtil.PATTERN_PREFIX, separator, StringUtil.PATTERN_SUFFIX);
+      } catch (PopulatePatternException pe){
+          logger.warn(pe.getMessage());
+          return ""; //TODO: this is the default behaviour, do we want to return a zero length string when populating the pattern has failed?
+      }
+
    }
 
    public static String populateStateVariables(String command, Cmd cmd, State state) {

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/ScriptContext.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/ScriptContext.java
@@ -8,6 +8,7 @@ import io.hyperfoil.tools.qdup.SshSession;
 import io.hyperfoil.tools.qdup.State;
 import io.hyperfoil.tools.qdup.cmd.impl.ScriptCmd;
 import io.hyperfoil.tools.yaup.AsciiArt;
+import io.hyperfoil.tools.yaup.PopulatePatternException;
 import io.hyperfoil.tools.yaup.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.ext.XLogger;
@@ -369,7 +370,13 @@ public class ScriptContext implements Context, Runnable{
                 if (cmd.hasSignalWatchers()){
                     Supplier<String> inputSupplier = ()->getSession().peekOutput();
                     for(String name : cmd.getSignalNames()){
-                        String populatedName = StringUtil.populatePattern(name,new CmdStateRefMap(cmd,state,null),true);
+                        String populatedName = null;
+                        try {
+                            populatedName = StringUtil.populatePattern(name,new CmdStateRefMap(cmd,state,null),true);
+                        } catch (PopulatePatternException e) {
+                            logger.warn(e.getMessage());
+                            populatedName = "";
+                        }
                         List<Cmd> toCall = cmd.getSignal(name);
                         Cmd root = new ActiveCheckCmd(getCurrentCmd());
                         SyncContext syncContext = new SyncContext(this.getSession(),this.getState(),this.getRun(),this.getProfiler(),root,this);

--- a/src/main/java/io/hyperfoil/tools/qdup/config/RunConfigBuilder.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/RunConfigBuilder.java
@@ -10,6 +10,7 @@ import io.hyperfoil.tools.qdup.config.waml.WamlParser;
 import io.hyperfoil.tools.qdup.config.yaml.YamlFile;
 import io.hyperfoil.tools.yaup.HashedLists;
 import io.hyperfoil.tools.yaup.HashedSets;
+import io.hyperfoil.tools.yaup.PopulatePatternException;
 import io.hyperfoil.tools.yaup.StringUtil;
 import io.hyperfoil.tools.yaup.json.Json;
 import org.slf4j.ext.XLogger;
@@ -574,8 +575,14 @@ public class RunConfigBuilder {
 
         for(String alias : hostAlias.keySet()){
            String value = hostAlias.get(alias);
-           String populatedValue = StringUtil.populatePattern(value,map,false);
-           if(populatedValue.contains(StringUtil.PATTERN_PREFIX)){
+            String populatedValue = null;
+            try {
+                populatedValue = StringUtil.populatePattern(value,map,false);
+            } catch (PopulatePatternException e) {
+                logger.warn(e.getMessage());
+                populatedValue="";
+            }
+            if(populatedValue.contains(StringUtil.PATTERN_PREFIX)){
               addError("cannot create host from "+value+" -> "+populatedValue);
            }
            Host host = Host.parse(populatedValue);


### PR DESCRIPTION
This is related to https://github.com/Hyperfoil/yaup/pull/21

With the changes to yaup to throw exceptions when populatePattern fails, the exceptions need handling in qDup.  The default behaviour has not changed, i.e. if there is a failure to populate the expression a zero length string is returned "", however the failure is now logged.