### PR TITLE
Do no write out state value if `silent: true`

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
@@ -85,7 +85,7 @@ public class SetState extends Cmd {
         String useValue = populatedValue != null ? populatedValue : value;
 
         if(isSilent()){
-            return "set-state: "+key+" "+value;
+            return "set-state: " + useKey;
         }
         return "set-state: " + useKey + " " + (useValue.trim().isEmpty() ? "\"\"" : useValue);
     }


### PR DESCRIPTION
Currently, if silent is set for the set-state cmd, the state value is still written to the run log
e.g.: 
```
- set-state: 
    key: VALUES 
    value: ${{VALUES}}<value metricComparator="LB" metricName="quarkus_started_time" result="${{startTime}}"><parameters><parameter name="cpu" value="${{CPU.cores}}"/></parameters></value>
    silent: true
```


This PR changes the behaviour of set-state cmd such that if the `silent: true` option is defined for the cmd, the state value is not written to the log.  A line is logged to record that the state variable has been set, but the value of the state is not written
