### PR TITLE
Command line option to supress logging of state values

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/JarMain.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/JarMain.java
@@ -221,6 +221,14 @@ public class JarMain {
             .build()
       );
 
+      options.addOption(
+        Option.builder(null)
+                .longOpt("quietstate")
+                .hasArg(false)
+                .desc("Supress output of state variables from run log")
+                .build()
+      );
+
 
       CommandLineParser parser = new DefaultParser();
       HelpFormatter formatter = new HelpFormatter();
@@ -394,6 +402,10 @@ public class JarMain {
 
       if (commandLine.hasOption("trace")) {
          runConfigBuilder.trace(commandLine.getOptionValue("trace"));
+      }
+
+      if (commandLine.hasOption("quietstate")) {
+         runConfigBuilder.supressStateOutput(true);
       }
 
       RunConfig config = runConfigBuilder.buildConfig();

--- a/src/main/java/io/hyperfoil/tools/qdup/Run.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/Run.java
@@ -432,8 +432,10 @@ public class Run implements Runnable, DispatchObserver {
             }
             String tree = config.getState().tree();
 
-            String filteredTree = getConfig().getState().getSecretFilter().filter(tree);
-            runLogger.info("{} starting state:\n{}",config.getName(),filteredTree);
+            if (!getConfig().getState().isSuppressed()) {
+                String filteredTree = getConfig().getState().getSecretFilter().filter(tree);
+                runLogger.info("{} starting state:\n{}", config.getName(), filteredTree);
+            }
             boolean ok = nextStage();
             if(ok) {
                 try {
@@ -703,9 +705,10 @@ public class Run implements Runnable, DispatchObserver {
         logger.debug("{}.postRun",this);
         String tree = config.getState().tree();
 
-        String filteredTree = getConfig().getState().getSecretFilter().filter(tree);
-
-        runLogger.info("{} closing state:\n{}",config.getName(),filteredTree);
+        if(!getConfig().getState().isSuppressed()) {
+            String filteredTree = getConfig().getState().getSecretFilter().filter(tree);
+            runLogger.info("{} closing state:\n{}", config.getName(), filteredTree);
+        }
 
         runLatch.countDown();
     }

--- a/src/main/java/io/hyperfoil/tools/qdup/State.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/State.java
@@ -7,6 +7,7 @@ import io.hyperfoil.tools.yaup.json.Json;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 /**
@@ -40,6 +41,15 @@ public class State {
     private String prefix;
     private SecretFilter secretFilter;
 
+    private AtomicBoolean supressOutput = new AtomicBoolean(false);
+
+    public void setSuppressOutput(boolean suppress) {
+        this.supressOutput.set(suppress);
+    }
+
+    public boolean isSuppressed(){
+        return this.supressOutput.get();
+    }
 
     public static class CmdState extends State {
         private final Cmd cmd;

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
@@ -84,7 +84,7 @@ public class SetState extends Cmd {
         String useKey = populatedKey != null ? populatedKey : key;
         String useValue = populatedValue != null ? populatedValue : value;
 
-        if(isSilent()){
+        if(isSilent() || context.getState().isSuppressed()){
             return "set-state: "+key+" "+value;
         }
         return "set-state: " + useKey + " " + (useValue.trim().isEmpty() ? "\"\"" : useValue);

--- a/src/main/java/io/hyperfoil/tools/qdup/config/RunConfigBuilder.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/RunConfigBuilder.java
@@ -112,6 +112,9 @@ public class RunConfigBuilder {
       traceTargets.add(pattern);
    }
 
+   public void supressStateOutput(boolean supress) {
+      this.state.setSuppressOutput(supress);
+   }
    public Set<String> getTracePatterns() {
       return traceTargets;
    }


### PR DESCRIPTION
I have had a request to disable logging of state variable values , both during a run and at start and end of run.
This PR provides a new command line option that disables writing state variables to the run log

@willr3 please can you take a look and see if I have missed other places where state values can be written to the log