### PR TITLE
State Logger to control logging of state values

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/Run.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/Run.java
@@ -168,6 +168,7 @@ public class Run implements Runnable, DispatchObserver {
         fileAppender.start();
 
         stateLogger = (Logger) LoggerFactory.getLogger(STATE_LOGGER_NAME);
+        stateLogger.addAppender(fileAppender);
         runLogger = (Logger) LoggerFactory.getLogger(RUN_LOGGER_NAME);
         runLogger.addAppender(fileAppender);
         if(!runLogger.isAttached(consoleAppender)) {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,6 +17,7 @@
     </appender>
     <logger name="io.hyperfoil.tools.qdup.Local" level="INFO"/>
     <logger name="io.hyperfoil.tools.qdup.cmd.Dispatcher" level="INFO"/>
+    <logger name="stateLogger" level="DEBUG"/>
 <!--    <logger name="org.apache.sshd" level="debug"/>-->
 
     <root level="info">

--- a/src/test/java/io/hyperfoil/tools/qdup/RunTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/RunTest.java
@@ -348,14 +348,9 @@ public class RunTest extends SshTestBase {
       Dispatcher dispatcher = new Dispatcher();
       Run doit = new Run(tmpDir.toString(), config, dispatcher);
 
-      //Instantiate a StringBuilderAppender to capture state logger output
-      StringBuilderAppender stringWriterAppender = new StringBuilderAppender();
-      stringWriterAppender.start();
-      doit.getStateLogger().addAppender(stringWriterAppender);
-
       doit.run();
 
-      String logContents = stringWriterAppender.getLog();
+      String logContents = readFile(tmpDir.getPath().resolve("run.log"));
 
       Boolean containsStrartingState = logContents.contains("starting state:");
       Boolean containsOutputState = logContents.contains("closing state:");
@@ -1087,16 +1082,4 @@ public class RunTest extends SshTestBase {
       assertTrue("run-env output should contain JAVA_OPTS", runEnv.contains("JAVA_OPTS"));
    }
 
-   private class StringBuilderAppender extends AppenderBase {
-      private StringBuilder inMemLog = new StringBuilder();
-
-      @Override
-      protected void append(Object eventObject) {
-         inMemLog.append( ((LoggingEvent) eventObject).getMessage());
-      }
-
-      public String getLog(){
-          return inMemLog.toString();
-      }
-   }
 }


### PR DESCRIPTION
Introduce a new stateLogger for state variables, to allow user to control log levels of state variables at start and end of a run