### PR TITLE
Add RunConfig.getRoles() method to return roles map from RunConfig

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/config/RunConfig.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/RunConfig.java
@@ -122,6 +122,7 @@ public class RunConfig {
     }
 
     public Set<String> getRoleNames(){return roles.keySet();}
+    public Map<String, Role> getRoles(){ return roles;}
     public Role getRole(String name){
         return roles.get(name);
     }


### PR DESCRIPTION
Allows for more simple iteration over roles in RunConfig, e.g;

`runconfig.getRoles().forEach( (name, value) -> System.out.println(value));`

instead of

`runconfig.getRoleNames().forEach( key -> System.out.println(runconfig.getRole(key)));`

