### PR TITLE
Add auto convert option to set-state and Regex commands

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/State.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/State.java
@@ -136,19 +136,26 @@ public class State {
         }
         secretFilter.loadSecrets(state.getSecretFilter());
     }
+
     public void load(Json json){
         json.forEach((key,value)->{
-            set(key.toString(),value);
-//            if(value instanceof Json){
+            if(value instanceof Json){
+                if (((Json)value).has("value") && ((Json)value).has("autoConvert") && ((Json)value).size() == 2) {
+                    String stateValue = ((Json)value).getString("value");
+                    boolean autoConvert = ((Json)value).getBoolean("autoConvert");
+                    set(key.toString(), stateValue, autoConvert);
+                } else {
+                    set(key.toString(),value.toString(), true);
+                }
 //                String childPrefix = null;
 //                if(RUN_PREFIX.equals(this.prefix)){
 //                    childPrefix = HOST_PREFIX;
 //                }
 //                State childState = getChild(key.toString(),childPrefix);
 //                childState.load((Json)value);
-//            }else{
-//                set(key.toString(),value.toString());
-//            }
+            }else{
+                set(key.toString(),value.toString(), true);
+            }
         });
     }
 
@@ -182,8 +189,16 @@ public class State {
         childStates.putIfAbsent(name,new State(this,prefix));
         return childStates.get(name);
     }
-    public void set(String key,Object value){
-        value = convertType(value);
+
+    public void set(String key,Object value) {
+        this.set( key, value, true);
+    }
+
+    public void set(String key, Object value, boolean autoConvert){
+        if (autoConvert) {
+            value = convertType(value);
+        }
+
         State target = this;
         boolean isSecret = key.startsWith(SecretFilter.SECRET_NAME_PREFIX);
 

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
@@ -4,7 +4,6 @@ import io.hyperfoil.tools.qdup.Coordinator;
 import io.hyperfoil.tools.qdup.SecretFilter;
 import io.hyperfoil.tools.qdup.State;
 import io.hyperfoil.tools.qdup.cmd.impl.*;
-import io.hyperfoil.tools.yaup.AsciiArt;
 import io.hyperfoil.tools.yaup.HashedLists;
 import io.hyperfoil.tools.yaup.PopulatePatternException;
 import io.hyperfoil.tools.yaup.StringUtil;
@@ -14,7 +13,9 @@ import org.slf4j.ext.XLoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -244,6 +245,10 @@ public abstract class Cmd {
 
    public static Regex regex(String pattern) {
       return new Regex(pattern);
+   }
+
+   public static Regex regex(String pattern, boolean autoConvert) {
+      return new Regex(pattern, false, autoConvert);
    }
 
    public static Cmd repeatUntil(String name) {
@@ -622,9 +627,6 @@ public abstract class Cmd {
    }
 
    public Cmd with(String key, Object value) {
-      if(value instanceof String){
-         value = State.convertType(value);
-      }
       withDef.set(key, value);
       withActive.set(key, value);
       return this;

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/Regex.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/Regex.java
@@ -19,16 +19,21 @@ public class Regex extends CmdWithElse {
    private boolean miss = false;
    private Map<String, String> matches;
    private boolean ran = false;
+   private boolean autoConvert = true;
 
    public Regex(String pattern) {
       this(pattern, false);
    }
 
    public Regex(String pattern, boolean miss) {
+      this(pattern, miss, true);
+   }
+   public Regex(String pattern, boolean miss, boolean autoConvert) {
       this.pattern = pattern;
       this.miss = miss;
       this.patternString = StringUtil.removeQuotes(pattern).replaceAll("\\\\\\\\(?=[dDsSwW\\(\\)remo])", "\\\\");
       this.matches = new HashMap<>();
+      this.autoConvert = autoConvert;
    }
 
 
@@ -48,6 +53,10 @@ public class Regex extends CmdWithElse {
 
    public String getPattern() {
       return patternString;
+   }
+
+   public Boolean isAutoConvert(){
+      return autoConvert;
    }
 
    @Override
@@ -95,7 +104,7 @@ public class Regex extends CmdWithElse {
                }
                if (!matches.isEmpty()) {
                   for (String key : matches.keySet()) {
-                     context.getState().set(key, matches.get(key));
+                     context.getState().set(key, matches.get(key), this.autoConvert);
                   }
                }
             }
@@ -139,7 +148,7 @@ public class Regex extends CmdWithElse {
 
    @Override
    public Cmd copy() {
-      return new Regex(this.patternString, this.miss);
+      return new Regex(this.patternString, this.miss, this.autoConvert);
    }
 
 

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/SetState.java
@@ -14,20 +14,27 @@ public class SetState extends Cmd {
     String value;
     String populatedKey;
     String populatedValue;
+    Boolean autoConvert;
 
     public SetState(String key) {
         this(key, null);
     }
 
     public SetState(String key, String value) {
-        this(key,value,StringUtil.PATTERN_DEFAULT_SEPARATOR,false);
+        this(key,value,StringUtil.PATTERN_DEFAULT_SEPARATOR,false, true);
     }
-    public SetState(String key, String value,String separator, boolean silent) {
+
+    public SetState(String key, String value, boolean autoConvert) {
+        this(key,value,StringUtil.PATTERN_DEFAULT_SEPARATOR, false, autoConvert);
+    }
+
+    public SetState(String key, String value, String separator, boolean silent, boolean autoConvert) {
         super(silent);
         this.key = key;
         this.value = value;
         setPatternSeparator(separator);
         //this.separator = separator;
+        this.autoConvert = autoConvert;
     }
 
     public String getKey() {
@@ -59,12 +66,12 @@ public class SetState extends Cmd {
                 if (Json.isJsonLike(populatedValue) /*&& populatedValue.contains(StringUtil.PATTERN_PREFIX) && populatedValue.contains(StringUtil.PATTERN_SUFFIX)*/) {
                     Json fromPopulatedValue = Json.fromString(populatedValue);
                     if (fromPopulatedValue!=null && !fromPopulatedValue.isEmpty()) {
-                        context.getState().set(populatedKey, fromPopulatedValue);
+                        context.getState().set(populatedKey, fromPopulatedValue, autoConvert);
                     } else {
-                        context.getState().set(populatedKey, populatedValue);
+                        context.getState().set(populatedKey, populatedValue, autoConvert);
                     }
                 } else {
-                    context.getState().set(populatedKey, populatedValue);
+                    context.getState().set(populatedKey, populatedValue, autoConvert);
                 }
             }catch (Exception e){
                 e.printStackTrace();
@@ -75,7 +82,7 @@ public class SetState extends Cmd {
 
     @Override
     public Cmd copy() {
-        return new SetState(key, value, getPatternSeparator(), silent);
+        return new SetState(key, value, getPatternSeparator(), silent, autoConvert);
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/qdup/config/yaml/Parser.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/yaml/Parser.java
@@ -393,7 +393,8 @@ public class Parser {
                     json.getString("key"),
                     json.getString("value", null),
                     json.getString("separator", StringUtil.PATTERN_DEFAULT_SEPARATOR),
-                    json.getBoolean("silent", false)
+                    json.getBoolean("silent", false),
+                    json.getBoolean("autoConvert", true)
                 )
         );
         rtrn.addCmd(

--- a/src/main/java/io/hyperfoil/tools/qdup/config/yaml/RegexConstruct.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/yaml/RegexConstruct.java
@@ -9,7 +9,11 @@ public class RegexConstruct extends CmdConstruct {
       super(
          "regex",
          (str,prefix,suffix)->new Regex(str),
-         (json)-> new Regex(json.getString("pattern",""),json.getBoolean("miss",false))
+         (json)-> new Regex(
+                 json.getString(RegexMapping.PATTERN,"")
+                 ,json.getBoolean(RegexMapping.MISS,false)
+                 ,json.getBoolean(RegexMapping.AUTO_CONVERT,false)
+         )
       );
       this.addTopLevelkey("else",(cmd,node)->{
          if(cmd instanceof Regex && node instanceof SequenceNode){

--- a/src/main/java/io/hyperfoil/tools/qdup/config/yaml/RegexMapping.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/yaml/RegexMapping.java
@@ -8,6 +8,7 @@ import java.util.*;
 public class RegexMapping extends CmdMapping {
 
    public static final String MISS = "miss";
+   public static final String AUTO_CONVERT = "autoConvert";
    public static final String PATTERN = "pattern";
    public static final String ELSE = "else";
 
@@ -22,6 +23,7 @@ public class RegexMapping extends CmdMapping {
                   Map<Object,Object> regexMap = new HashMap<>();
                   regexMap.put(PATTERN,r.getPattern());
                   regexMap.put(MISS,r.isMiss());
+                  regexMap.put(AUTO_CONVERT,r.isAutoConvert());
                   return regexMap;
                }else{
                   return r.getPattern();

--- a/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/SetStateTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/SetStateTest.java
@@ -92,6 +92,20 @@ public class SetStateTest extends SshTestBase {
    }
 
    @Test
+   public void check_state_type_casting() {
+
+      SetState setState = new SetState("timestamp","20210307110018725", false);
+      setState.setPatternSeparator("_");
+      SpyContext spyContext = new SpyContext();
+
+      setState.run("",spyContext);
+
+      assertTrue("state should have a timestamp",spyContext.getState().has("timestamp"));
+      assertEquals("capture timestamp from pattern", "20210307110018725", spyContext.getState().get("timestamp"));
+
+   }
+
+   @Test
    public void replace_regex_in_yaml_cmd_separator(){
       String mac = "00:11:22:33:44:0b";
       Parser parser = Parser.getInstance();


### PR DESCRIPTION
... to control if state should be auto converted to numeric Type

Calls to `State.set()` will automatically attempt to convert the type of `value` to an Integer or Double.  If `value` can be converted, it will be stored as a numeric type in the State tree.

When we have a string that represents a time stamp, or another similarly large number, the timestamp will be stored as a double, e.g. for a pattern;
 `file: /tmp/(?<framework>.*)-(?<timestamp>\\d*)/index.html` 
and the input `file: /tmp/quarkussimulation-20210307110018725/index.html`

References to `${{timestamp}}` in the script substitute the value `2.0210307110018724E16`.  References to invoke js toString() on the state value result in rounding errors, e.g. `${{= ${{timestamp}}.toString() }}` resolves to `20210307110018724`

@willr3  In order to mitigate these rounding errors, I have added an `autoConvert` ro `regex` and `set-state` to force `State.set()` to store the value as a String in the state map.

With this PR, it is now possible to disable auto-converting numeric type state variables when they are stored in the state tree, e.g.

````
- regex:
    pattern: "file: /tmp/reports/(?<framework>.*)-(?<timestamp>\\d*)/index.html"
    autoConvert: false

- set-state: 
    key: RUN.BAR 
    value: ${{FOO}}
    autoConvert: false

run-scripts:
  - foo:
      with:
        FOO:
          value: "0024"
          autoConvert: false

states:
  FOO: 
    value: "0001"
    autoConvert: false
````