### PR TITLE
YAML spec allows for colon(:) in scalar values only if they are not f…

### DIFF
--- a/src/test/java/io/hyperfoil/tools/qdup/RunTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/RunTest.java
@@ -97,7 +97,6 @@ public class RunTest extends SshTestBase {
    }
 
 
-
    @Test
    public void pwd_in_dollar() {
       Parser parser = Parser.getInstance();
@@ -105,7 +104,7 @@ public class RunTest extends SshTestBase {
       builder.loadYaml(parser.loadFile("pwd", stream("" +
          "scripts:",
          "  foo:",
-         "    - sh: echo \"pwd is: $(pwd)\"",
+         "    - sh: echo \"pwd is:$(pwd)\"",
          "    - echo:",
          "hosts:",
          "  local: " + getHost(),


### PR DESCRIPTION
…ollowed by a space, even if the scalar value is container in quotes

The test yaml was failing to parse