### PR TITLE
Rename main class to QDup and introduce new static run() method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>io.hyperfoil.tools.qdup.JarMain</mainClass>
+                            <mainClass>io.hyperfoil.tools.qdup.QDup</mainClass>
                         </manifest>
                         <manifestEntries>
                             <hash>${git.commit.id.abbrev}</hash>


### PR DESCRIPTION
Rename main class to QDup and introduce static `run()` method, so that invoking qDup programtically becomes;
`QDup.run(args);`

instead of

`JarMain.main(args);`

