### PR TITLE
Allow definition of Max download size: fixes #71

### DIFF
--- a/docs/command/download.adoc
+++ b/docs/command/download.adoc
@@ -4,16 +4,18 @@ This command copies a file from the host to the qDup run directory and passes th
 
 [source,yaml]
 ----
-- download: path [destination]
+- download: path [destination] [max-size]
 - download:
     path: /tmp/log/ #the path on the remote host
     destination: log #the local destination relative to the qdup host output folder
+    max-size: 1000 #the maximum size file to download.
 ----
 
 There are 2 arguments to download:
 
 - `path` the path to the file on the remote host. This is a required argument. Relative paths (paths that do not start with `/`) will be prefixed with the current pwd of the remote terminal.
 - `destination` the local path for file copied from the remote host. This is an optional arguent and will default to the filename from the `path`. The `destination` is always relative to the current qDup working directory and host directory.
+- `max-size` the maximum file size to download. This is an optional argument and if the file is larger than the maximum size set, the file will not be downloaded and a WARN message will be written to the run log.  Max-size can be specified as number of bytes, or using standard notation, e.g. 5MB, 1GB etc
 
 
 .qdup.yaml

--- a/docs/command/queuedownload.adoc
+++ b/docs/command/queuedownload.adoc
@@ -12,5 +12,6 @@ The download will only happen after cleanup if `queue-download` is called in `cl
 - queue-download:
     path: /tmp/gc.log
     destination: driver1/gc.log
+    max-size: 10000
 ---
 

--- a/src/main/java/io/hyperfoil/tools/qdup/Local.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/Local.java
@@ -260,7 +260,7 @@ public class Local {
 
    }
 
-   private void runRsyncCmd(List<String> cmd, String action, Consumer<String> lineConsumer){
+   private void runRsyncCmd(List<String> cmd, String action, Consumer<String> inputStreamConsumer){
       ProcessBuilder builder = new ProcessBuilder();
       builder.command(cmd);
       logger.debug("Running rsync command : " + cmd.stream().collect(Collectors.joining(" ")));
@@ -281,7 +281,7 @@ public class Local {
          }
          reader = new BufferedReader(new InputStreamReader(inputStream));
          while ((line = reader.readLine()) != null) {
-            lineConsumer.accept(line);
+            inputStreamConsumer.accept(line);
          }
 
       } catch (IOException e) {

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/Cmd.java
@@ -299,6 +299,14 @@ public abstract class Cmd {
       return new Download(path, destination);
    }
 
+   public static Cmd download(String path, Long maxSize) {
+      return new Download(path, maxSize);
+   }
+
+   public static Cmd download(String path, String destination, Long maxSize) {
+      return new Download(path, destination, maxSize);
+   }
+
    public static Cmd upload(String path, String destination) {
       return new Upload(path, destination);
    }
@@ -337,6 +345,14 @@ public abstract class Cmd {
 
    public static Cmd queueDownload(String path, String destination) {
       return new QueueDownload(path, destination);
+   }
+
+   public static Cmd queueDownload(String path, String destination, Long maxSize) {
+      return new QueueDownload(path, destination, maxSize);
+   }
+
+   public static Cmd queueDownload(String path, Long maxSize) {
+      return new QueueDownload(path, maxSize);
    }
 
    public static Cmd readState(String name) {

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/Context.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/Context.java
@@ -34,7 +34,7 @@ public interface Context {
     SshSession getSession();
     Host getHost();
     State getState();
-    void addPendingDownload(String path,String destination);
+    void addPendingDownload(String path,String destination, Long maxSize);
     void addPendingDelete(String path);
     void abort(Boolean skipCleanup);
     void done();

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/ScriptContext.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/ScriptContext.java
@@ -185,8 +185,8 @@ public class ScriptContext implements Context, Runnable{
 
     public State getState(){return state;}
     @Override
-    public void addPendingDownload(String path,String destination){
-        run.addPendingDownload(session.getHost(),path,destination);
+    public void addPendingDownload(String path,String destination, Long maxSize){
+        run.addPendingDownload(session.getHost(),path,destination, maxSize);
     }
     @Override
     public void addPendingDelete(String path){

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/SyncContext.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/SyncContext.java
@@ -180,8 +180,8 @@ public class SyncContext implements Context, Runnable{
     }
 
     @Override
-    public void addPendingDownload(String path, String destination) {
-        run.addPendingDownload(session.getHost(),path,destination);
+    public void addPendingDownload(String path, String destination, Long maxSize) {
+        run.addPendingDownload(session.getHost(),path,destination,maxSize);
     }
     @Override
     public void addPendingDelete(String path){

--- a/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/QueueDownload.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/cmd/impl/QueueDownload.java
@@ -11,16 +11,31 @@ public class QueueDownload extends Cmd {
     private String populatedPath;
     private String destination;
     private String populatedDestination;
-    public QueueDownload(String path, String destination){
+    private Long maxSize;
+
+    public QueueDownload(String path, String destination, Long maxFileSize){
         this.path = path;
         this.destination = destination;
         if(this.destination==null){
             this.destination="";
         }
+        if( maxFileSize != null && maxFileSize > 0) {
+            this.maxSize = maxFileSize;
+        } else {
+            this.maxSize = null;
+        }
+
+    }
+    public QueueDownload(String path, String destination){
+        this(path, destination, null);
     }
     public QueueDownload(String path){
         this(path,"");
     }
+    public QueueDownload(String path, Long maxFileSize) {
+        this(path,"", maxFileSize);
+    }
+
     public String getPath(){return path;}
     public String getDestination(){return destination;}
 
@@ -63,7 +78,7 @@ public class QueueDownload extends Cmd {
         }
         populatedPath = resolvedPath;
         populatedDestination = resolvedDestination;
-        context.addPendingDownload(resolvedPath,resolvedDestination);
+        context.addPendingDownload(resolvedPath,resolvedDestination, maxSize);
 
         File destinationFile = new File(resolvedDestination);
         if(!destinationFile.exists()){
@@ -74,15 +89,21 @@ public class QueueDownload extends Cmd {
 
     @Override
     public Cmd copy() {
-        return new QueueDownload(path,destination);
+        return new QueueDownload(path,destination,maxSize);
     }
 
     @Override
     public String getLogOutput(String output,Context context){
+        StringBuilder logBuild = new StringBuilder("queue-download: ");
         if(populatedPath!=null){
-            return "queue-download: "+populatedPath+" "+populatedDestination;
+            logBuild.append(populatedPath).append(" ").append(populatedDestination);
         }else{
-            return "queue-download: "+path+" "+destination;
+            logBuild.append(path).append(" ").append(destination);
         }
+        if( maxSize != null){
+            logBuild.append(" max-size: ").append(maxSize);
+        }
+
+        return logBuild.toString();
     }
 }

--- a/src/main/java/io/hyperfoil/tools/qdup/config/converter/FileSizeConverter.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/converter/FileSizeConverter.java
@@ -1,0 +1,43 @@
+package io.hyperfoil.tools.qdup.config.converter;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FileSizeConverter {
+
+    static final Pattern pattern = Pattern.compile("(?<sizeValue>[\\d.]+)(?<sizeUnit>[GMK]?B)*", Pattern.CASE_INSENSITIVE);
+    static final Map<String, Integer> powerMap;
+
+    static {
+        powerMap = new HashMap<>();
+        powerMap.put("B", 0);
+        powerMap.put("KB", 1);
+        powerMap.put("MB", 2);
+        powerMap.put("GB", 3);
+        powerMap.put("TB", 4);
+        powerMap.put("PB", 5);
+        powerMap.put("EB", 6);
+    }
+    public static long toBytes(String fileSize){
+        long returnValue = -1;
+        if( fileSize != null) {
+            Matcher matcher = pattern.matcher(fileSize);
+            if (matcher.find()) {
+                String value = matcher.group("sizeValue");
+                String unit = matcher.group("sizeUnit");
+                if(unit == null){
+                    unit = "B";
+                }
+                int pow = powerMap.get(unit.toUpperCase());
+                BigDecimal bytes = new BigDecimal(value);
+                bytes = bytes.multiply(BigDecimal.valueOf(1024).pow(pow));
+                returnValue = bytes.longValue();
+            }
+        }
+        return returnValue;
+
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/qdup/config/yaml/Parser.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/yaml/Parser.java
@@ -6,6 +6,7 @@ import io.hyperfoil.tools.qdup.cmd.Cmd;
 import io.hyperfoil.tools.qdup.cmd.Script;
 import io.hyperfoil.tools.qdup.cmd.impl.*;
 import io.hyperfoil.tools.qdup.config.Role;
+import io.hyperfoil.tools.qdup.config.converter.FileSizeConverter;
 import io.hyperfoil.tools.yaup.StringUtil;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
@@ -153,11 +154,13 @@ public class Parser {
                         return new Download(str);
                     } else if (split.size() == 2) {
                         return new Download(split.get(0), split.get(1));
+                    } else if (split.size() == 3) {
+                        return new Download(split.get(0), split.get(1), FileSizeConverter.toBytes(split.get(2)));
                     } else {
                         throw new YAMLException("cannot create download from " + str);
                     }
                 },
-                (json) -> new Download(json.getString("path"), json.getString("destination", ""))
+                (json) -> new Download(json.getString("path"), json.getString("destination", ""), FileSizeConverter.toBytes(json.getString("max-size", null)))
 
         );
         rtrn.addCmd(
@@ -233,12 +236,14 @@ public class Parser {
                         return new QueueDownload(split.get(0));
                     } else if (split.size() == 2) {
                         return new QueueDownload(split.get(0), split.get(1));
+                    } else if (split.size() == 3) {
+                        return new QueueDownload(split.get(0), split.get(1), FileSizeConverter.toBytes(split.get(2)));
                     } else {
                         throw new YAMLException("cannot create queue-download from " + str);
                     }
                 },
                 (json) -> {
-                    return new QueueDownload(json.getString("path"), json.getString("destination", ""));
+                    return new QueueDownload(json.getString("path"), json.getString("destination", ""), FileSizeConverter.toBytes(json.getString("max-size", null)));
                 }
         );
         rtrn.addCmd(

--- a/src/test/java/io/hyperfoil/tools/qdup/cmd/SpyContext.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/cmd/SpyContext.java
@@ -152,7 +152,7 @@ public class SpyContext implements Context {
     }
 
     @Override
-    public void addPendingDownload(String path, String destination) {
+    public void addPendingDownload(String path, String destination, Long maxSize) {
 
     }
     @Override

--- a/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/UploadTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/UploadTest.java
@@ -21,9 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 public class UploadTest extends SshTestBase {
 
-//    @Rule
-//    public final TestServer testServer = new TestServer();
-
     @Test
     public void uploadFile(){
         try {


### PR DESCRIPTION
With this PR users can define a max file size for `download` and `queue-download` commands, which will *not* download a remote file if it is larger than the defined max size and print a WARNING.  This prevents unexpectedly large files from being downloaded from remote machines.

e.g.;

````
- download:
    path: /tmp/log/
    destination: log
    max-size: 10MB
````