### PR TITLE
Bump testcontainer version to 1.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,9 +134,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-<!-- Can not connect to Ryuk at localhost:32777 -->
-<!--            <version>1.12.5</version> -->
-            <version>1.5.1</version>
+            <version>1.16.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
version 1.5.1 was causing test failures with Docker 20.10.6