### PR TITLE
Upgrade logback to 1.2.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,12 +175,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.10</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.10</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
logback-classic:1.2.3 and logback-core:1.2.3 are both susceptible to CVE-2021-42550