### PR TITLE
Expose config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/src/main/java/io/hyperfoil/tools/qdup/JsonServer.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/JsonServer.java
@@ -313,7 +313,7 @@ public class JsonServer implements RunObserver, ContextObserver {
             logger.info("listening at localhost:{}", foundPort);
         }
 
-        server.requestHandler(router::accept).listen(foundPort/*, InetAddress.getLocalHost().getHostName()*/);
+        server.requestHandler(router).listen(foundPort/*, InetAddress.getLocalHost().getHostName()*/);
     }
 
     public void stop(){

--- a/src/main/java/io/hyperfoil/tools/qdup/QDup.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/QDup.java
@@ -59,6 +59,8 @@ public class QDup {
 
     private boolean exitCode = false;
 
+    private static RunConfig config;
+
     public boolean checkExitCode(){return exitCode;}
 
     public boolean isColorTerminal() {
@@ -140,6 +142,8 @@ public class QDup {
     public List<Stage> getSkipStages(){
         return skipStages;
     }
+
+    public static String getRunDebug(){ return config.debug(true); };
 
     public QDup(String... args) {
         Options options = new Options();
@@ -514,10 +518,10 @@ public class QDup {
             qDup.getSkipStages().forEach(runConfigBuilder::addSkipStage);
         }
 
-        RunConfig config = runConfigBuilder.buildConfig(yamlParser);
+        config = runConfigBuilder.buildConfig(yamlParser);
         if (qDup.isTest()) {
             //logger.info(config.debug());
-            System.out.printf("%s", config.debug(true));
+            System.out.printf("%s", getRunDebug());
             System.exit(0);
         }
 


### PR DESCRIPTION
- Make QDup.run() non-static to allow re-use as library
- Expose RunConfig object for use as a library
- Set version for maven-jar-plugin to remove build warnings
- Remove deprecated vert.x method call