### PR TITLE
Disable json server

### DIFF
--- a/docs/jar.adoc
+++ b/docs/jar.adoc
@@ -42,6 +42,9 @@ java -jar qDup-uber.jar -B /tmp/ qdup.yaml util.yaml
 == monitoring
 
 qDup starts a JSON server for run monitoring and debug. The default port is `31337` but can be changed with `--jsonport`.
+
+The JSON server can be disabled by setting the System Property `-DdisableRestApi=true`
+
 The endpoints are the follwing:
 
 GET /state :: current qDup state

--- a/src/main/java/io/hyperfoil/tools/qdup/QDup.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/QDup.java
@@ -674,16 +674,23 @@ public class QDup {
             }
         }, "shutdown-abort"));
 
-        JsonServer jsonServer = new JsonServer(run, getJsonPort());
+        Boolean startJsonServer = !Boolean.parseBoolean(System.getProperty("disableRestApi", "false"));
 
-        jsonServer.start();
+        JsonServer jsonServer = null;
+        if (startJsonServer) {
+            jsonServer = new JsonServer(run, getJsonPort());
+
+            jsonServer.start();
+        }
 
         long start = System.currentTimeMillis();
         run.getRunLogger().info("Running qDup version {} @ {}", getVersion(), getHash());
         run.run();
         long stop = System.currentTimeMillis();
         System.out.printf("Finished in %s at %s%n", StringUtil.durationToString(stop - start), run.getOutputPath());
-        jsonServer.stop();
+        if (startJsonServer) {
+            jsonServer.stop();
+        }
         dispatcher.shutdown();
         executor.shutdownNow();
         scheduled.shutdownNow();


### PR DESCRIPTION
This provides the option of disabling the JSON REST api via a system property `disableRestApi`. The default behaviour is uneffected