### PR TITLE
 Do not count reset set-signal commands in SignalCounts - Fixes #137 

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/config/rule/SignalCounts.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/config/rule/SignalCounts.java
@@ -81,7 +81,9 @@ public class SignalCounts implements RunRule {
             if(Cmd.hasStateReference(populated,command)){
                 //TODO do we warn about signal something that cannot resolve at compile time
             }
-            signals.add(populated);
+            if( !((SetSignal) command).isReset()) {
+                signals.add(populated);
+            }
         }
     }
 

--- a/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/RepeatUntilSignalTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/RepeatUntilSignalTest.java
@@ -1,10 +1,22 @@
 package io.hyperfoil.tools.qdup.cmd.impl;
 
+import io.hyperfoil.tools.qdup.Run;
+import io.hyperfoil.tools.qdup.SshTestBase;
+import io.hyperfoil.tools.qdup.State;
 import io.hyperfoil.tools.qdup.cmd.Cmd;
+import io.hyperfoil.tools.qdup.cmd.Dispatcher;
+import io.hyperfoil.tools.qdup.config.RunConfig;
+import io.hyperfoil.tools.qdup.config.RunConfigBuilder;
+import io.hyperfoil.tools.qdup.config.yaml.Parser;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class RepeatUntilSignalTest {
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class RepeatUntilSignalTest extends SshTestBase  {
 
     @Test
     public void selfSignaling(){
@@ -39,6 +51,53 @@ public class RepeatUntilSignalTest {
 
         Assert.assertEquals("2.next should be repeat",true,two.getNext().toString().contains("FOO"));
         Assert.assertEquals("repeat.skip should be 3",true,repeat.getSkip().toString().contains("3"));
+    }
+
+    @Test
+    public void setSignalCountTest(){
+        Parser parser = Parser.getInstance();
+        RunConfigBuilder builder = getBuilder();
+        builder.loadYaml(parser.loadFile("", stream("" +
+                "scripts:",
+                "  repeat-until:",
+                "  - repeat-until: TEST_DONE",
+                "    then:",
+                "    - wait-for: READY",
+                "    - set-state: RUN.counter ${{= ${{RUN.counter}} + 1}}",
+                "    - set-signal: READY 1",
+                "  run-test:",
+                "  - for-each:",
+                "      name: it",
+                "      input: ${{tests}}",
+                "    then:",
+                "    - log: running test ${{it}}",
+                "    - signal: READY",
+                "    - sleep: 1s",
+                "  - signal: TEST_DONE",
+                "hosts:",
+                "  local: " + getHost(),
+                "roles:",
+                "  doit:",
+                "    hosts: [local]",
+                "    run-scripts:",
+                "      - repeat-until",
+                "      - run-test",
+                "states:",
+                "  counter: 0",
+                "  tests: ['test1', 'test2', 'test3']"
+        )));
+
+        RunConfig config = builder.buildConfig(parser);
+        assertFalse("unexpected errors:\n"+config.getErrors().stream().map(Objects::toString).collect(Collectors.joining("\n")),config.hasErrors());
+
+        Dispatcher dispatcher = new Dispatcher();
+        Run doit = new Run(tmpDir.toString(), config, dispatcher);
+
+        doit.run();
+        dispatcher.shutdown();
+        State state = config.getState();
+        assertTrue("state should have key",state.has("counter"));
+        assertEquals(3,state.get("counter"));
     }
 
 }

--- a/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/RepeatUntilSignalTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/cmd/impl/RepeatUntilSignalTest.java
@@ -72,7 +72,7 @@ public class RepeatUntilSignalTest extends SshTestBase  {
                 "    then:",
                 "    - log: running test ${{it}}",
                 "    - signal: READY",
-                "    - sleep: 1s",
+                "    - sleep: 500",
                 "  - signal: TEST_DONE",
                 "hosts:",
                 "  local: " + getHost(),
@@ -97,7 +97,7 @@ public class RepeatUntilSignalTest extends SshTestBase  {
         dispatcher.shutdown();
         State state = config.getState();
         assertTrue("state should have key",state.has("counter"));
-        assertEquals(3,state.get("counter"));
+        assertEquals(3l,state.get("counter"));
     }
 
 }

--- a/src/test/java/io/hyperfoil/tools/qdup/config/rule/SignalCountsTest.java
+++ b/src/test/java/io/hyperfoil/tools/qdup/config/rule/SignalCountsTest.java
@@ -423,7 +423,10 @@ public class SignalCountsTest extends SshTestBase {
         builder.loadYaml(parser.loadFile("signal",stream(""+
                 "scripts:",
                 "  test:",
-                "    - set-signal: ${{BAR}} 1",
+                "    - set-signal:",
+                "        name: ${{BAR}}",
+                "        count: 1",
+                "        reset: false",
                 "    - wait-for: FOO",
                 "hosts:",
                 "  local: me@localhost",
@@ -482,7 +485,10 @@ public class SignalCountsTest extends SshTestBase {
         builder.loadYaml(parser.loadFile("signal",stream(""+
                 "scripts:",
                 "  test:",
-                "    - set-signal: FOO 1",
+                "    - set-signal:",
+                "        name: FOO",
+                "        count: 1",
+                "        reset: false",
                 "    - wait-for: FOO",
                 "hosts:",
                 "  local: me@localhost",


### PR DESCRIPTION
@willr3 please can you review. This PR distinguishes between `set-signal` resets and new signals. It introduces a breaking change to the semantics of `set-signal`