### PR TITLE
Added configuration to not fail when .git directory missing.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
                 </executions>
                 <configuration>
                     <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR fixes #200  integration to enable worktrees to operate when running Maven goals.