### PR TITLE
Issue 215

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/shell/ContainerShell.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/shell/ContainerShell.java
@@ -96,7 +96,11 @@ public class ContainerShell extends AbstractShell{
                     //TODO how to fail when container start fails
                 }else{
                     containerId = shell.shSync(populatedCommand,null,connectTimeoutSeconds);
-                    if(containerId.contains("\n") || containerId.isBlank()){
+                    if(containerId.contains("Error:") || containerId.isBlank()){
+                        //there was an error reported from container runtime
+                        logger.error("error starting {} container {} : {}",getHost().isLocal() ? "local" : "remote", getHost().getSafeString(), containerId);
+                        return null;
+                    } else if(containerId.contains("\n") || containerId.isBlank()){
                         //assume the container started connected
                         //cannot shSync because connection is not ready...
                         rtrn = shell.commandStream;


### PR DESCRIPTION
Fixes #215

A failure message is now logged;

```
08:06:35.762 Running qDup version 0.8.2 @ 68705d4
08:06:35.763 output path = /tmp/20240619_080634
08:06:35.763 shell exit code checks enabled
08:06:35.904 json server listening at fedora:31337
08:06:37.070 error starting local container LOCAL//registry.fedoraproject.org/f35/python3 : Error: OCI runtime error: crun: cannot setresuid to `1001`: Invalid argument
08:06:37.071  failed to connect to LOCAL//registry.fedoraproject.org/f35/python3
08:06:37.071 setup failed to connect LOCAL//registry.fedoraproject.org/f35/python3
08:06:37.077 failed to connect all ssh sessions for setup
Finished in 01.147 at /tmp/20240619_080634
```