### PR TITLE
Add error details for failed container start: Fixes #215

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/shell/ContainerShell.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/shell/ContainerShell.java
@@ -96,7 +96,11 @@ public class ContainerShell extends AbstractShell{
                     //TODO how to fail when container start fails
                 }else{
                     containerId = shell.shSync(populatedCommand,null,connectTimeoutSeconds);
-                    if(containerId.contains("\n") || containerId.isBlank()){
+                    if(containerId.contains("Error:") || containerId.isBlank()){
+                        //there was an error reported from container runtime
+                        logger.error("error starting {} container {} : {}",getHost().isLocal() ? "local" : "remote", getHost().getSafeString(), containerId);
+                        return null;
+                    } else if(containerId.contains("\n") || containerId.isBlank()){
                         //assume the container started connected
                         //cannot shSync because connection is not ready...
                         rtrn = shell.commandStream;


### PR DESCRIPTION
When a container runtime reports an error when trying to start a container, the detail of the error is missing;

```
07:59:20.910 Running qDup version 0.8.2 @ 68705d4
07:59:20.911 output path = /tmp/qdup-debug
07:59:20.911 shell exit code checks enabled
07:59:21.074 json server listening at fedora:31337
07:59:22.497  failed to connect to LOCAL//registry.fedoraproject.org/f35/python3
07:59:22.498 setup failed to connect LOCAL//registry.fedoraproject.org/f35/python3
07:59:22.502 failed to connect all ssh sessions for setup
```

It would improve UX if the details of the error were logged so that a user can begin troubleshooting problems