### PR TITLE
qDup requires Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [FAQ](./docs/FAQ.md) for frequently asked questions.
 
 qDup builds to a single executable jar that includes all its dependencies using [Apache Maven](http://maven.apache.org/).
 
-qDup requires [Java 11](https://adoptopenjdk.net/) or higher.
+qDup requires [Java 17](https://adoptopenjdk.net/) or higher.
 
 ```sh
 mvn clean package


### PR DESCRIPTION
qDup requires Java 17

See: https://github.com/Hyperfoil/qDup/blob/master/pom.xml#L14
```xml
<maven.compiler.target>17</maven.compiler.target>
```