### PR TITLE
Log features

### DIFF
--- a/src/main/java/io/hyperfoil/tools/qdup/shell/AbstractShell.java
+++ b/src/main/java/io/hyperfoil/tools/qdup/shell/AbstractShell.java
@@ -356,7 +356,7 @@ public abstract class AbstractShell {
     }
     void sh(String command, boolean acquireLock, BiConsumer<String,String> callback, Map<String, String> prompt) {
         command = command.replaceAll("[\r\n]+$", ""); //replace trailing newlines
-        logger.trace("{} sh: {}, lock: {}", getHost(), command, acquireLock);
+        logger.info("{} sh: {}, lock: {}", getHost(), command, acquireLock);
         ShAction newAction = new ShAction(command,acquireLock,callback,prompt);
         lastCommand = command;
         if (command == null || commandStream == null) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -8,7 +8,7 @@
             </PatternLayout>
         </File>
         <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
-            <PatternLayout disableAnsi="false" pattern="%highlight{%d{HH:mm:ss.SSS} %m%n}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=white, DEBUG=green bold, TRACE=blue}"/>
+            <PatternLayout disableAnsi="false" pattern="%highlight{%d{HH:mm:ss.SSS} [%p] %m%n}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=white, DEBUG=green bold, TRACE=blue}"/>
         </Console>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
With the current implementation ( by color ) the output in Jenkins is the following. This PR aims to improve that by adding the logging level.

qDup with the code on master will product the following on Jenkins
```
[m[37m18:28:23.018 run-hello-world-setup:2012@mwperf-server03: stop-env: 
[m[37m18:28:23.417 starting 3 scripts
[m[37m18:28:23.417 hyperfoil-start-in-container:2057@mwperf-server03: script-cmd: hyperfoil-start-in-container
[m[37m18:28:23.418 run-benchmark:2059@mwperf-server03: script-cmd: run-benchmark
[m[37m18:28:23.418 run-application:2061@mwperf-server03: script-cmd: run-application
[m[37m18:28:23.418 hyperfoil-start-in-container:2057@mwperf-server03: hyperfoil-start-in-container
[m[37m18:28:23.418 run-application:2061@mwperf-server03: run-application
[m[37m18:28:23.418 run-benchmark:2059@mwperf-server03: run-benchmark
[m[37m18:28:23.830 run-application:2061@mwperf-server03: cd /tmp/quarkus-quickstarts/getting-started-reactive
[m[37m18:28:24.424 run-application:2061@mwperf-server03: regex: getting-started-reactive.*started in
[m[37m18:28:24.425 reached APP_RUNNING
[m[37m18:28:24.425 run-benchmark:2059@mwperf-server03: wait-for: APP_RUNNING
[m[37m18:28:24.425 run-application:2061@mwperf-server03: signal: APP_RUNNING
[m[37m18:28:34.253 hyperfoil-start-in-container:2057@mwperf-server03: regex: ControllerVerticle deployed
[m[37m18:28:34.254 reached HYPERFOIL_CONTROLLER_STARTED
[m[37m18:28:34.254 run-benchmark:2059@mwperf-server03: wait-for: HYPERFOIL_CONTROLLER_STARTED
[m[37m18:28:34.254 hyperfoil-start-in-container:2057@mwperf-server03: signal: HYPERFOIL_CONTROLLER_STARTED
[m[31m18:28:34.255 File does not exist for upload: /var/jenkins_home/workspace/test/assets/example.hf.yaml
[m[31m18:28:34.255 run-benchmark:2059@mwperf-server03: failed to upload /var/jenkins_home/workspace/test/assets/example.hf.yaml to /tmp/example.hf.yaml
```