### PR TITLE
Implement --version/-V support

### DIFF
--- a/cli/src/main/java/io/hyperfoil/tools/qdup/cli/QDupPico.java
+++ b/cli/src/main/java/io/hyperfoil/tools/qdup/cli/QDupPico.java
@@ -12,8 +12,6 @@ import io.quarkus.arc.Arc;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
 import io.vertx.core.Vertx;
-import io.vertx.ext.web.Router;
-import io.vertx.ext.web.handler.BodyHandler;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -34,8 +32,6 @@ import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -44,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 @QuarkusMain
-@CommandLine.Command(name="qdup", description = "performance test automation", mixinStandardHelpOptions = true, subcommands={CommandLine.HelpCommand.class, AutoComplete.GenerateCompletion.class})
+@CommandLine.Command(name="qdup", description = "performance test automation", mixinStandardHelpOptions = true, subcommands={CommandLine.HelpCommand.class, AutoComplete.GenerateCompletion.class}, versionProvider = QDupVersionProvider.class)
 public class QDupPico implements Callable<Integer>, QuarkusApplication {
 
     private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());

--- a/cli/src/main/java/io/hyperfoil/tools/qdup/cli/QDupVersionProvider.java
+++ b/cli/src/main/java/io/hyperfoil/tools/qdup/cli/QDupVersionProvider.java
@@ -1,0 +1,33 @@
+package io.hyperfoil.tools.qdup.cli;
+
+import io.hyperfoil.tools.qdup.QDup;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class QDupVersionProvider implements CommandLine.IVersionProvider {
+    @Override
+    public String[] getVersion() throws Exception {
+        Properties properties = new Properties();
+        try (InputStream is = QDup.class.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+            if (is != null) {
+                properties.load(is);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        try (InputStream is = QDup.class.getResourceAsStream("/META-INF/maven/io.hyperfoil.tools/qDup/pom.properties")) {
+            if (is != null) {
+                properties.load(is);
+
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        String version = properties.getProperty("version", "unknown");
+
+        return new String[]{version};
+    }
+}


### PR DESCRIPTION
`java -jar qDup.jar -V` returns nothing.

This PR introduces a version provider so that picocli can pick up the version and give the following output:

```
java -jar qDup.jar -V
0.10.5-SNAPSHOT
```