### PR TITLE
Skip trailing nulls in SuffixStream

### DIFF
--- a/qDup/src/main/java/io/hyperfoil/tools/qdup/stream/SuffixStream.java
+++ b/qDup/src/main/java/io/hyperfoil/tools/qdup/stream/SuffixStream.java
@@ -255,6 +255,11 @@ public class SuffixStream extends MultiStream {
         consumers.forEach(c -> c.accept(name));
     }
     public int suffixLength(byte b[], byte toFind[], int endIndex){
+        // Skip trailing nulls that some custom shell prompts seam to append
+        while (endIndex > 0 && b[endIndex-1] == 0) {
+            endIndex--;
+        }
+
         boolean matching = false;
         int rtrn = 0;
         for(int shift=Math.max(0,toFind.length-endIndex); shift< toFind.length && !matching; shift++){


### PR DESCRIPTION
Some prompts like starship in zsh emit these after the prompt

Closes https://github.com/Hyperfoil/qDup/issues/244
